### PR TITLE
Introduce property to toggle RSS feed in the series panel

### DIFF
--- a/src/main/resources/config/mir-navigation-plugin/mycore.properties
+++ b/src/main/resources/config/mir-navigation-plugin/mycore.properties
@@ -11,7 +11,7 @@ MCR.URIResolver.xslImports.solr-document=%MCR.URIResolver.xslImports.solr-docume
 ######################################################################
 ##                  RSS Feed for journals and series                ##
 ######################################################################
-
+MIR.Metadata.Navigation.SeriesPanel.RSS.Enabled=true
 #MCR.LayoutTransformerFactory.Default.Ignore=mycoreobject-rss,%MCR.LayoutTransformerFactory.Default.Ignore%
 #DuEPublico.RSS.Generator=DuEPublico\: Duisburg-Essen Publications Online, University of Duisburg-Essen, Germany
 

--- a/src/main/resources/xsl/series-panel.xsl
+++ b/src/main/resources/xsl/series-panel.xsl
@@ -12,6 +12,7 @@
   <xsl:param name="WebApplicationBaseURL" />
   <xsl:param name="CurrentLang" />
   <xsl:param name="ServletsBaseURL" />
+  <xsl:param name="MIR.Metadata.Navigation.SeriesPanel.RSS.Enabled" />
   
   <xsl:template match="mycoreobject" mode="seriesLayout">
     <xsl:apply-templates select="structure/derobjects/derobject[classification[@classid='derivate_types'][@categid='navigation']]/@xlink:href" mode="seriesLayout">
@@ -45,9 +46,11 @@
         <div class="card-body">
           <ul>
             <xsl:apply-templates select="item" mode="seriesLayout" />
-            <xsl:call-template name="rssLink">
-              <xsl:with-param name="rootID" select="$rootID" />
-            </xsl:call-template>
+            <xsl:if test="$MIR.Metadata.Navigation.SeriesPanel.RSS.Enabled='true'">
+              <xsl:call-template name="rssLink">
+                <xsl:with-param name="rootID" select="$rootID" />
+              </xsl:call-template>
+            </xsl:if>
           </ul>
         </div>
 


### PR DESCRIPTION
The RSS feed requires configuration and has dependencies, such as `mycoreobject-rss`, which is currently not part of MyCore/MIR. Therefore, the feature is not complete and should not be enabled by default. For compatibility reasons, I have introduced a property that allows to toggle it.